### PR TITLE
docs: improve setup and troubleshooting guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # npm
 node_modules
+.env*.local
 
 # Don't include the compiled main.js file in the repo.
 # They should be uploaded to GitHub releases instead.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Slidev
+# Slidev for Obsidian
 
-Preview Markdown presentations from Obsidian with [Slidev](https://sli.dev/).
+Preview Markdown presentations from your Obsidian vault with
+[Slidev](https://sli.dev/). The plugin opens the active note in an embedded
+presentation view and keeps the displayed slide aligned with your cursor.
 
 [![Slidev presentation view in Obsidian](./docs/screenshot.png)](./docs/screencast.mp4)
 
@@ -10,7 +12,9 @@ Preview Markdown presentations from Obsidian with [Slidev](https://sli.dev/).
 ## Requirements
 
 - The desktop version of Obsidian. The plugin starts a local Node.js process and does not support mobile Obsidian.
-- [Node.js](https://nodejs.org/en/download) supported by your Slidev project. The current version of Slidev requires Node.js 20.12 or later.
+- [Node.js](https://nodejs.org/en/download) compatible with the version of
+  Slidev installed in your project. Check Slidev's own installation output or
+  package requirements when choosing a Node.js version.
 - A Slidev project with `@slidev/cli` installed locally in its `node_modules` directory. A global `slidev` command is neither required nor used.
 - Write access to the Slidev project while a presentation starts. The plugin creates a hidden temporary entry and bridge configuration there so Slidev can use that project's themes, addons, and components with notes stored elsewhere.
 
@@ -32,9 +36,11 @@ The plugin does not install or update Node.js, Slidev, themes, or project depend
 3. Create `<your-vault>/.obsidian/plugins/slidev/` and place the three files in that directory.
 4. Restart Obsidian, then enable **Slidev** under **Settings → Community plugins**.
 
-## Set up Slidev
+## Configure Slidev
 
-Create a Slidev project by following the [official getting-started guide](https://sli.dev/guide/) and install its dependencies. For example:
+Create a Slidev project by following the
+[official getting-started guide](https://sli.dev/guide/) and install its
+dependencies. For example:
 
 ```sh
 pnpm create slidev
@@ -42,14 +48,41 @@ cd <your-slidev-project>
 pnpm install
 ```
 
-Then open **Settings → Slidev** and configure:
+Then open **Settings → Slidev**:
 
-1. **Slidev project folder**: the project directory that contains `node_modules/@slidev/cli/package.json`.
-2. **Node.js executable**: leave this empty to find `node` from Obsidian's inherited `PATH`, or enter the absolute executable path if a shell-based version manager is not visible to Obsidian.
-3. **Port**: the local port for the Slidev server. The default is `3030`.
-4. Select **Verify** and resolve any reported setup problem.
+1. Set **Slidev project folder** to the project directory containing
+   `node_modules/@slidev/cli/package.json`.
+2. Leave **Node.js executable** empty to use `node` from Obsidian's inherited
+   `PATH`. If Obsidian cannot find a shell-managed Node.js installation, enter
+   the absolute path to the executable.
+3. Keep the default **Port** (`3030`) or choose a free port from 1 through 65535.
+4. Select **Verify** beside the project folder and resolve any reported issue.
 
-Open a Markdown note and run **Slidev: Open presentation view** from the command palette. If a Slidev server already responds on the configured port, the plugin connects to it. Otherwise, it starts the configured project's local Slidev CLI for the active note.
+The other settings are optional:
+
+- **Show slide numbers in reading view** labels Slidev separators with the
+  number of the following slide.
+- **Debug mode** adds server controls and process output to the presentation
+  view.
+
+## Present a note
+
+1. Open an existing Markdown note stored in a local vault.
+2. Run **Slidev: Open presentation view** from the command palette, or select
+   the presentation icon in the ribbon.
+3. If no server responds on the configured port, select **Start Slidev
+   server**. The view also attempts to start it when opened.
+
+The plugin connects to an existing server on the configured port when one is
+available. Otherwise, it launches the configured project's local Slidev CLI
+for the active note. Closing the view stops only the process started by that
+view. Changing the active note restarts that owned process for the new note.
+
+Use standard Slidev Markdown in the note, including `---` slide separators.
+The buttons above the embedded deck open the current slide in a browser or open
+Slidev's presenter view.
+
+If startup fails, see [Common problems](./docs/common-problems.md).
 
 ## Disclosures
 
@@ -60,7 +93,7 @@ Slidev preserves Obsidian's offline-first model, with the following local access
 - **External process:** When a presentation needs a server, the plugin starts the configured Node.js executable with the project-local Slidev CLI and the temporary project-local entry as separate arguments, without a shell. That entry imports the active Markdown file. The plugin stops only the process it started when the presentation view closes; it does not stop a server that was already running.
 - **Trusted content:** Slidev presentations can compile and execute Vue/JavaScript and read files they reference. Only launch notes, themes, addons, and project code you trust.
 
-## Development
+## Contributing
 
 ```sh
 git clone https://github.com/nirtamir2/obsidian-slidev.git
@@ -71,9 +104,30 @@ pnpm run type-check
 pnpm run build
 ```
 
-Production builds are written to `dist/`. To build directly into a development vault, set `OUT_DIR` to that vault's `.obsidian/plugins/slidev` directory in a local Vite environment file.
+Useful commands:
 
-[See common development problems](./docs/common-problems.md).
+| Command                 | Purpose                                            |
+| ----------------------- | -------------------------------------------------- |
+| `pnpm dev`              | Watch source files and rebuild in development mode |
+| `pnpm test`             | Run the Vitest test suite once                     |
+| `pnpm run lint`         | Check TypeScript, JavaScript, and JSON with ESLint |
+| `pnpm run format:check` | Check formatting with Prettier                     |
+| `pnpm run type-check`   | Check TypeScript without emitting files            |
+| `pnpm run build`        | Create a production build                          |
+| `pnpm run verify:build` | Verify the generated plugin artifacts              |
+| `pnpm run ci`           | Run the complete local CI pipeline                 |
+
+Production builds are written to `dist/`. To build directly into a development
+vault, set `OUT_DIR` to the vault's `.obsidian/plugins/slidev` directory in
+`.env.development.local`, then run `pnpm dev`:
+
+```dotenv
+OUT_DIR=/absolute/path/to/vault/.obsidian/plugins/slidev
+```
+
+Do not commit that machine-specific environment file. See
+[Common problems](./docs/common-problems.md#development-build-output) if the
+output is not where you expect.
 
 ## Credits
 

--- a/docs/common-problems.md
+++ b/docs/common-problems.md
@@ -1,5 +1,15 @@
 # Common problems
 
+Start with **Settings → Slidev → Verify**. It checks the configured project,
+its local `@slidev/cli` installation, and the Node.js executable without
+starting a presentation.
+
+## No active Markdown file
+
+The plugin presents the active file, and that file must already exist as a
+Markdown note in a vault stored on the local file system. Open or create a
+`.md` note, save it, and reopen the presentation view.
+
 ## Node.js was not found
 
 Obsidian is a desktop app, so it may inherit a different `PATH` from your
@@ -9,7 +19,8 @@ executable, then select **Verify** again.
 
 Use `which node` on macOS/Linux or `Get-Command node` in PowerShell to find the
 path. The plugin invokes that executable directly and does not source shell
-profile files.
+profile files. Enter the executable itself, not the containing directory and
+not a shell command such as `nvm use`.
 
 ## The local Slidev package is missing
 
@@ -18,11 +29,38 @@ The selected project must contain
 verify the same folder again. A globally installed `slidev` command is ignored
 deliberately.
 
+If the package is listed in the project's `package.json` but the file is
+missing, run the package manager's install command from that project folder
+(for example, `pnpm install` or `npm install`).
+
+## The project folder cannot be verified
+
+Select the Slidev project root, not its `node_modules` directory and not the
+Obsidian vault. The selected folder must be an existing, writable directory
+containing `node_modules/@slidev/cli/package.json` after dependencies are
+installed.
+
 ## The server does not become reachable
 
-Check that no unrelated process occupies the configured port. Enable **Debug
-mode** to see Slidev's process output, then correct the reported theme, addon,
-or project error and select **Start** again.
+Check that no unrelated process occupies the configured port. If the process
+on that port is a Slidev server you intend to use, select **Check again**. If it
+is unrelated, stop it or configure another port from 1 through 65535.
+
+Enable **Debug mode** to expose **Start**, **Stop**, and **View log** controls
+and to inspect Slidev's process output. Correct the reported theme, addon, or
+project error, then select **Start** again. The plugin waits up to 30 seconds
+for a newly launched server to become reachable.
+
+## Note-relative images or project features do not work
+
+The active note remains in the vault, but Slidev runs from the configured
+project so it can use that project's themes, addons, components, and installed
+dependencies. Keep those dependencies in the configured project. Reference
+vault media with paths that are valid from the note; the temporary bridge
+allows Slidev's Vite server to serve permitted files below the vault root.
+
+Slidev Markdown can execute Vue and JavaScript. Only use notes and project code
+you trust.
 
 ## Temporary Slidev files remain
 
@@ -34,5 +72,12 @@ the configured project.
 ## Development build output
 
 Vite creates the configured output directory automatically. Production builds
-use `dist/`; for development, set `OUT_DIR` to the target vault's
-`.obsidian/plugins/slidev` directory and run `pnpm dev`.
+use `dist/`. For development, create `.env.development.local` in the repository
+root, set `OUT_DIR` to the absolute path of the target vault's
+`.obsidian/plugins/slidev` directory, and run `pnpm dev`.
+
+```dotenv
+OUT_DIR=/absolute/path/to/vault/.obsidian/plugins/slidev
+```
+
+Vite writes `main.js`, `manifest.json`, and `styles.css` to that directory.

--- a/docs/superpowers/specs/2026-07-12-documentation-audit-design.md
+++ b/docs/superpowers/specs/2026-07-12-documentation-audit-design.md
@@ -1,0 +1,38 @@
+# Documentation accuracy audit
+
+## Goal
+
+Make the plugin documentation accurate, concise, and usable by someone installing the plugin, configuring a local Slidev project, troubleshooting startup, or contributing to the repository.
+
+## Scope
+
+- Audit `README.md`, `docs/common-problems.md`, and `slidev-template/README.md` against the current implementation and package scripts.
+- Correct inaccurate commands, labels, requirements, paths, and behavior descriptions.
+- Reorganize the root README around the reader journey: install, configure, present, troubleshoot, and develop.
+- Explain settings and common failures where users encounter them, while keeping detailed troubleshooting in `docs/common-problems.md`.
+- Verify repository-relative links and local media targets.
+- Preserve the existing disclosure of local network, filesystem, process, and trusted-content behavior.
+
+## Content rules
+
+- Treat the source code, `package.json`, `manifest.json`, and build configuration as the authority for current behavior.
+- Use the exact labels shown by Obsidian and the plugin UI.
+- Include commands that can be run as written and state their working directory when it is not obvious.
+- Avoid promising behavior the plugin does not implement.
+- Link to official upstream documentation for Slidev and Node.js rather than duplicating version-sensitive guidance.
+- Keep internal implementation rationale in the existing decision record instead of expanding the user-facing README.
+
+## Verification
+
+- Check every Markdown link and repository-relative media target.
+- Compare documented scripts with `package.json` and `slidev-template/package.json`.
+- Compare documented settings and commands with `SlidevSettingTab.ts` and `SlidevPlugin.ts`.
+- Run formatting checks and the repository test/build pipeline after edits.
+- Review the final diff for unsupported claims, placeholders, accidental changes, and secrets.
+
+## Out of scope
+
+- Plugin behavior changes.
+- New screenshots or screencasts.
+- Changes to historical plans or the accepted launcher decision record unless they contain a broken link that affects navigation.
+- The pre-existing change to `slidev-template/.obsidian/workspace.json`.

--- a/slidev-template/README.md
+++ b/slidev-template/README.md
@@ -1,11 +1,27 @@
-# Welcome to [Slidev](https://github.com/slidevjs/slidev)!
+# Slidev example project
 
-To start the slide show:
+This directory is a standalone [Slidev](https://sli.dev/) project and can also
+be selected as the **Slidev project folder** in the Obsidian plugin settings.
 
-- `npm install`
-- `npm run dev`
-- visit <http://localhost:3030>
+Install its dependencies first:
 
-Edit the [slides.md](./slides.md) to see the changes.
+```sh
+npm install
+```
 
-Learn more about Slidev at the [documentation](https://sli.dev/).
+To run this example directly, use `npm run dev` and open
+<http://localhost:3030>. Edit [slides.md](./slides.md) to see live changes.
+
+When using this directory with the Obsidian plugin, you do not need to start
+Slidev yourself. Open a Markdown note in Obsidian, run **Slidev: Open
+presentation view**, and let the plugin launch this project's local
+`@slidev/cli` installation.
+
+Other project commands:
+
+| Command | Purpose |
+| --- | --- |
+| `npm run build` | Build the example presentation |
+| `npm run export` | Export the example with Slidev |
+
+Learn more in the [Slidev documentation](https://sli.dev/guide/).


### PR DESCRIPTION
## What changed

- reorganized the README around installation, configuration, presenting, troubleshooting, and contributing
- documented every current setting and the presentation lifecycle
- expanded troubleshooting for Node.js, project validation, ports, local media, and temporary artifacts
- updated the bundled Slidev template instructions and command reference
- ignored machine-specific `.env*.local` files used by the documented development workflow

## Why

The existing documentation contained a version-sensitive Node.js requirement and did not fully explain the current project-local Slidev launcher, settings, presentation controls, or common setup failures.

## Impact

Users get an accurate setup path and actionable troubleshooting guidance. Contributors get a verified command reference and a safe way to build directly into a development vault. Plugin behavior is unchanged.

## Validation

- `pnpm run ci`
- 7 test files and 56 tests passed
- local documentation links and external targets checked
